### PR TITLE
Fix crash on exponent input

### DIFF
--- a/quantumwerewolf/cli.py
+++ b/quantumwerewolf/cli.py
@@ -70,7 +70,7 @@ class CliGame(Game):
     def ask_player(self, query, invalid_players=[]):
         answer = input(query + 'Name: ')
 
-        if answer.isdigit():
+        if answer.isdecimal():
             i = int(answer) - 1
             if i in range(self.player_count):
                 answer = self.players[i]


### PR DESCRIPTION
the check if the input for a player is a integer was incorrectly returning True for exponents like '²' but subsequently crashed when trying to convert this to an integer. Instead of using str.isdigit() we now use str.isdecimal() which gives correct behavior.